### PR TITLE
feat(scraper): add Harem physical gold tracking (gram & 22K bracelet)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           define('SCRAPE_USER_AGENT', 'Cybokron/1.0');
           define('SCRAPE_RETRY_COUNT', 3);
           define('SCRAPE_RETRY_DELAY', 5);
-          define('SCRAPE_ALLOWED_HOSTS', ['dunyakatilim.com.tr', 'www.dunyakatilim.com.tr', 'www.tcmb.gov.tr', 'tcmb.gov.tr', 'kur.doviz.com', 'doviz.com']);
+          define('SCRAPE_ALLOWED_HOSTS', ['dunyakatilim.com.tr', 'www.dunyakatilim.com.tr', 'www.tcmb.gov.tr', 'tcmb.gov.tr', 'kur.doviz.com', 'altin.doviz.com', 'doviz.com']);
           define('OPENROUTER_AI_REPAIR_ENABLED', true);
           define('OPENROUTER_API_KEY', '__OPENROUTER_API_KEY__');
           define('OPENROUTER_MODEL', 'z-ai/glm-5');

--- a/banks/HaremAltinScraper.php
+++ b/banks/HaremAltinScraper.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * HaremAltinScraper.php — Harem Fiziki Altın Scraper (altin.doviz.com)
+ * Cybokron Exchange Rate & Portfolio Tracking
+ *
+ * Scrapes physical gold prices from altin.doviz.com/harem/*.
+ * Unlike kur.doviz.com (bank FX table parsed by DovizComScraper), altin.doviz.com
+ * publishes each price in a live socket-bound cell:
+ *   <td data-socket-key="23-gram-altin" data-socket-attr="bid">6.534,39</td>
+ *   <td data-socket-key="23-gram-altin" data-socket-attr="ask">6.617,70</td>
+ *
+ * Prefix "23" is Harem's provider id on doviz.com. A single Harem page lists every
+ * Harem product, so we map only the products we track to our currency codes.
+ * bid = Alış (buy), ask = Satış (sell). Prices are TR-formatted (6.534,39).
+ *
+ * The provider id is hard-coded by design: if doviz.com changes it, scrape() returns
+ * 0 rates and the failure surfaces in scrape_logs — we never fall back to a different
+ * provider's price, because that would silently mis-value the user's holdings.
+ */
+
+class HaremAltinScraper extends Scraper
+{
+    // AI table-repair targets HTML <table> structure, not socket cells — disable
+    // it here so a low rate count never triggers a useless (and costly) OpenRouter call.
+    protected bool $supportsAutoRepair = false;
+
+    /**
+     * Harem socket-key (provider 23) → our currency code.
+     *
+     * @var array<string, string>
+     */
+    private array $productMap = [
+        '23-gram-altin'      => 'GRAMALTIN',
+        '23-22-ayar-bilezik' => 'BILEZIK22',
+    ];
+
+    public function scrape(string $html, DOMXPath $xpath, string $tableHash): array
+    {
+        $rates = [];
+
+        foreach ($this->productMap as $socketKey => $code) {
+            $buy  = $this->readSocketValue($xpath, $socketKey, 'bid');
+            $sell = $this->readSocketValue($xpath, $socketKey, 'ask');
+
+            if ($buy === null || $sell === null || $buy <= 0 || $sell <= 0) {
+                cybokron_log(
+                    "Harem scraper: missing/invalid price for {$socketKey} ({$code})",
+                    'WARNING'
+                );
+                continue;
+            }
+
+            $rates[] = [
+                'code'   => $code,
+                'buy'    => $buy,
+                'sell'   => $sell,
+                'change' => null,
+            ];
+        }
+
+        return $rates;
+    }
+
+    /**
+     * Read the first socket-bound cell value for a given key + attr (bid|ask).
+     */
+    private function readSocketValue(DOMXPath $xpath, string $socketKey, string $attr): ?float
+    {
+        // socketKey/attr come only from the trusted productMap above, so the
+        // literal XPath predicate below is safe from injection.
+        $nodes = $xpath->query(
+            '//*[@data-socket-key="' . $socketKey . '" and @data-socket-attr="' . $attr . '"]'
+        );
+
+        if (!$nodes instanceof DOMNodeList || $nodes->length === 0) {
+            return null;
+        }
+
+        return $this->parseRate($nodes->item(0)->textContent);
+    }
+
+    /**
+     * Parse TR-formatted price string to float (6.534,39 → 6534.39).
+     */
+    private function parseRate(string $text): ?float
+    {
+        $cleaned = str_replace([' ', '.', ','], ['', '', '.'], trim($text));
+
+        if ($cleaned === '' || !is_numeric($cleaned)) {
+            return null;
+        }
+
+        $rate = (float) $cleaned;
+
+        return $rate > 0 ? $rate : null;
+    }
+}

--- a/config.sample.php
+++ b/config.sample.php
@@ -48,7 +48,7 @@ define('SCRAPE_TIMEOUT', 30);         // HTTP request timeout in seconds
 define('SCRAPE_USER_AGENT', 'Cybokron/1.0');
 define('SCRAPE_RETRY_COUNT', 3);      // Retry failed requests
 define('SCRAPE_RETRY_DELAY', 5);      // Seconds between retries
-define('SCRAPE_ALLOWED_HOSTS', ['dunyakatilim.com.tr', 'www.dunyakatilim.com.tr', 'www.tcmb.gov.tr', 'tcmb.gov.tr', 'kur.doviz.com', 'doviz.com']);
+define('SCRAPE_ALLOWED_HOSTS', ['dunyakatilim.com.tr', 'www.dunyakatilim.com.tr', 'www.tcmb.gov.tr', 'tcmb.gov.tr', 'kur.doviz.com', 'altin.doviz.com', 'doviz.com']);
 define('OPENROUTER_AI_REPAIR_ENABLED', true);   // AI fallback only triggers when parsed row count is too low
 define('OPENROUTER_API_KEY', '');               // Set your API key from https://openrouter.ai
 define('OPENROUTER_MODEL', 'z-ai/glm-5');       // Default model (can be changed later via scripts/set_openrouter_model.php)

--- a/database/migrations/015_add_physical_gold.sql
+++ b/database/migrations/015_add_physical_gold.sql
@@ -1,0 +1,17 @@
+-- 015_add_physical_gold.sql
+-- Fiziki altın takibi: Harem (altin.doviz.com) kaynağından gram altın ve 22 ayar bilezik.
+-- XAU (ons saf altın) ile takip yanıltıcıydı; fiziki ürünler gram bazlı TL fiyatla takip edilir.
+
+-- 1) currencies.type ENUM'una 'physical_gold' ekle (mevcut değerler korunur)
+ALTER TABLE currencies
+    MODIFY COLUMN `type` enum('fiat','precious_metal','crypto','physical_gold') DEFAULT 'fiat';
+
+-- 2) Yeni para birimleri (gram bazlı fiziki altın). INSERT IGNORE: code UNIQUE, tekrar çalışmada atlar.
+INSERT IGNORE INTO currencies (`code`, `name_tr`, `name_en`, `symbol`, `type`, `decimal_places`, `is_active`) VALUES
+    ('GRAMALTIN', 'Gram Altın (Fiziki)', 'Physical Gram Gold', 'gr', 'physical_gold', 4, 1),
+    ('BILEZIK22', '22 Ayar Bilezik',     '22K Gold Bracelet',  'gr', 'physical_gold', 4, 1);
+
+-- 3) Harem fiziki altın kaynağı (tek sayfa, hem gram altın hem 22 ayar bilezik fiyatını içerir).
+--    INSERT IGNORE: slug UNIQUE, tekrar çalışmada atlar.
+INSERT IGNORE INTO banks (`name`, `slug`, `url`, `scraper_class`, `is_active`) VALUES
+    ('Harem Fiziki Altın', 'harem-fiziki', 'https://altin.doviz.com/harem/gram-altin', 'HaremAltinScraper', 1);

--- a/database/migrations/015_add_physical_gold.sql
+++ b/database/migrations/015_add_physical_gold.sql
@@ -1,17 +1,17 @@
 -- 015_add_physical_gold.sql
--- Fiziki altın takibi: Harem (altin.doviz.com) kaynağından gram altın ve 22 ayar bilezik.
--- XAU (ons saf altın) ile takip yanıltıcıydı; fiziki ürünler gram bazlı TL fiyatla takip edilir.
+-- Fiziki altın takibi: Harem altin.doviz.com kaynağından gram altın ve 22 ayar bilezik.
+-- XAU yani ons saf altın ile takip yanıltıcıydı; fiziki ürünler gram bazlı TL fiyatla takip edilir.
 
--- 1) currencies.type ENUM'una 'physical_gold' ekle (mevcut değerler korunur)
+-- 1. currencies.type ENUM tipine 'physical_gold' değeri ekle, mevcut değerler korunur.
 ALTER TABLE currencies
     MODIFY COLUMN `type` enum('fiat','precious_metal','crypto','physical_gold') DEFAULT 'fiat';
 
--- 2) Yeni para birimleri (gram bazlı fiziki altın). INSERT IGNORE: code UNIQUE, tekrar çalışmada atlar.
+-- 2. Yeni para birimleri, gram bazlı fiziki altın. INSERT IGNORE: code UNIQUE, tekrar çalışmada atlar.
 INSERT IGNORE INTO currencies (`code`, `name_tr`, `name_en`, `symbol`, `type`, `decimal_places`, `is_active`) VALUES
-    ('GRAMALTIN', 'Gram Altın (Fiziki)', 'Physical Gram Gold', 'gr', 'physical_gold', 4, 1),
-    ('BILEZIK22', '22 Ayar Bilezik',     '22K Gold Bracelet',  'gr', 'physical_gold', 4, 1);
+    ('GRAMALTIN', 'Gram Altın Fiziki', 'Physical Gram Gold', 'gr', 'physical_gold', 4, 1),
+    ('BILEZIK22', '22 Ayar Bilezik',   '22K Gold Bracelet', 'gr', 'physical_gold', 4, 1);
 
--- 3) Harem fiziki altın kaynağı (tek sayfa, hem gram altın hem 22 ayar bilezik fiyatını içerir).
+-- 3. Harem fiziki altın kaynağı. Tek sayfa hem gram altın hem 22 ayar bilezik fiyatını içerir.
 --    INSERT IGNORE: slug UNIQUE, tekrar çalışmada atlar.
 INSERT IGNORE INTO banks (`name`, `slug`, `url`, `scraper_class`, `is_active`) VALUES
     ('Harem Fiziki Altın', 'harem-fiziki', 'https://altin.doviz.com/harem/gram-altin', 'HaremAltinScraper', 1);


### PR DESCRIPTION
Track physical gold from altin.doviz.com/harem instead of misusing XAU (ounce spot) for physical holdings.

- Add HaremAltinScraper: reads socket-bound cells (data-socket-key="23-*", data-socket-attr="bid|ask") for Harem provider 23; bid=buy, ask=sell, TR price format. supportsAutoRepair disabled (socket cells, not a table).
- Migration 015: add 'physical_gold' currency type + GRAMALTIN and BILEZIK22 currencies + "Harem Fiziki Altın" bank source (idempotent INSERT IGNORE).
- Allow altin.doviz.com in SCRAPE_ALLOWED_HOSTS (config.sample + deploy.yml).

Tested locally: GRAMALTIN 6540.98/6623.21, BILEZIK22 5962.84/6235.02.