### PR TITLE
feat: portföy değer & kâr/zarar Alış/Satış ayrımı

### DIFF
--- a/includes/Portfolio.php
+++ b/includes/Portfolio.php
@@ -47,7 +47,9 @@ class Portfolio
                 g.icon AS group_icon,
                 (p.amount * p.buy_rate) AS cost_try,
                 (p.amount * COALESCE(r.sell_rate, p.buy_rate)) AS value_try,
-                ((COALESCE(r.sell_rate, p.buy_rate) - p.buy_rate) / p.buy_rate * 100) AS profit_percent
+                (p.amount * COALESCE(r.buy_rate, p.buy_rate)) AS value_try_buy,
+                ((COALESCE(r.sell_rate, p.buy_rate) - p.buy_rate) / p.buy_rate * 100) AS profit_percent,
+                ((COALESCE(r.buy_rate, p.buy_rate) - p.buy_rate) / p.buy_rate * 100) AS profit_percent_buy
             FROM portfolio p
             JOIN currencies c ON c.id = p.currency_id
             LEFT JOIN banks b ON b.id = p.bank_id
@@ -67,22 +69,29 @@ class Portfolio
         $items = self::getAll();
 
         $totalCost = 0.0;
-        $totalValue = 0.0;
+        $totalValue = 0.0;       // satış kuru (sell_rate) bazlı — yeniden alma değeri
+        $totalValueBuy = 0.0;    // alış kuru (buy_rate/bid) bazlı — bozdurma/nakit değeri
 
         foreach ($items as $item) {
             $totalCost += (float) $item['cost_try'];
             $totalValue += (float) $item['value_try'];
+            $totalValueBuy += (float) ($item['value_try_buy'] ?? $item['value_try']);
         }
 
         $profitLoss = $totalValue - $totalCost;
         $profitPercent = $totalCost > 0 ? ($profitLoss / $totalCost * 100) : 0;
+        $profitLossBuy = $totalValueBuy - $totalCost;
+        $profitPercentBuy = $totalCost > 0 ? ($profitLossBuy / $totalCost * 100) : 0;
 
         return [
             'items' => $items,
             'total_cost' => round($totalCost, 2),
             'total_value' => round($totalValue, 2),
+            'total_value_buy' => round($totalValueBuy, 2),
             'profit_loss' => round($profitLoss, 2),
             'profit_percent' => round($profitPercent, 2),
+            'profit_loss_buy' => round($profitLossBuy, 2),
+            'profit_percent_buy' => round($profitPercentBuy, 2),
             'item_count' => count($items),
         ];
     }

--- a/index.php
+++ b/index.php
@@ -291,10 +291,14 @@ foreach ($widgetConfig as $w) {
                 <!-- Portfolio Summary Card -->
                 <?php
                     $totalCost = (float) ($portfolioSummary['total_cost'] ?? 0);
-                    $totalValue = (float) ($portfolioSummary['total_value'] ?? 0);
+                    $totalValue = (float) ($portfolioSummary['total_value'] ?? 0);          // satış kuru
+                    $totalValueBuy = (float) ($portfolioSummary['total_value_buy'] ?? $totalValue); // alış kuru (bozdurma)
                     $profitPercent = (float) ($portfolioSummary['profit_percent'] ?? 0);
+                    $profitPercentBuy = (float) ($portfolioSummary['profit_percent_buy'] ?? $profitPercent);
                     $profitAmount = $totalValue - $totalCost;
+                    $profitAmountBuy = $totalValueBuy - $totalCost;
                     $isProfit = $profitPercent >= 0;
+                    $isProfitBuy = $profitPercentBuy >= 0;
                 ?>
                 <div class="widget-card">
                     <div class="widget-card-header">
@@ -308,17 +312,25 @@ foreach ($widgetConfig as $w) {
                                 <span class="portfolio-metric-value"><?= formatTRY($totalCost) ?></span>
                             </div>
                             <div class="portfolio-metric metric-highlight">
-                                <span class="portfolio-metric-label"><?= t('portfolio.summary.current_value') ?></span>
+                                <span class="portfolio-metric-label"><?= t('portfolio.summary.current_value_buy') ?></span>
+                                <span class="portfolio-metric-value"><?= formatTRY($totalValueBuy) ?></span>
+                            </div>
+                            <div class="portfolio-metric">
+                                <span class="portfolio-metric-label"><?= t('portfolio.summary.current_value_sell') ?></span>
                                 <span class="portfolio-metric-value"><?= formatTRY($totalValue) ?></span>
                             </div>
+                            <div class="portfolio-metric <?= $isProfitBuy ? 'metric-profit' : 'metric-loss' ?>">
+                                <span class="portfolio-metric-label"><?= t('portfolio.summary.profit_loss_buy') ?></span>
+                                <span class="portfolio-metric-value"><?= $isProfitBuy ? '+' : '' ?><?= formatTRY($profitAmountBuy) ?></span>
+                            </div>
                             <div class="portfolio-metric <?= $isProfit ? 'metric-profit' : 'metric-loss' ?>">
-                                <span class="portfolio-metric-label"><?= t('portfolio.summary.profit_loss') ?></span>
+                                <span class="portfolio-metric-label"><?= t('portfolio.summary.profit_loss_sell') ?></span>
                                 <span class="portfolio-metric-value"><?= $isProfit ? '+' : '' ?><?= formatTRY($profitAmount) ?></span>
                             </div>
                         </div>
-                        <div class="portfolio-profit-badge <?= $isProfit ? 'badge-profit' : 'badge-loss' ?>">
-                            <span class="badge-arrow"><?= $isProfit ? '▲' : '▼' ?></span>
-                            %<?= formatNumberLocalized(abs($profitPercent), 2) ?>
+                        <div class="portfolio-profit-badge <?= $isProfitBuy ? 'badge-profit' : 'badge-loss' ?>">
+                            <span class="badge-arrow"><?= $isProfitBuy ? '▲' : '▼' ?></span>
+                            %<?= formatNumberLocalized(abs($profitPercentBuy), 2) ?>
                         </div>
                         <a href="portfolio.php" class="btn-portfolio">
                             <?= t('nav.portfolio') ?>

--- a/locales/en.php
+++ b/locales/en.php
@@ -74,6 +74,10 @@ return [
     'portfolio.summary.total_cost' => 'Total Cost',
     'portfolio.summary.current_value' => 'Current Value',
     'portfolio.summary.profit_loss' => 'Profit / Loss',
+    'portfolio.summary.current_value_buy' => 'Current Value (Bid)',
+    'portfolio.summary.current_value_sell' => 'Current Value (Ask)',
+    'portfolio.summary.profit_loss_buy' => 'Profit / Loss (Bid)',
+    'portfolio.summary.profit_loss_sell' => 'Profit / Loss (Ask)',
 
     'portfolio.form.title' => 'Add to Portfolio',
     'portfolio.form.currency' => 'Currency',

--- a/locales/tr.php
+++ b/locales/tr.php
@@ -74,6 +74,10 @@ return [
     'portfolio.summary.total_cost' => 'Toplam Maliyet',
     'portfolio.summary.current_value' => 'Güncel Değer',
     'portfolio.summary.profit_loss' => 'Kâr / Zarar',
+    'portfolio.summary.current_value_buy' => 'Güncel Değer (Alış)',
+    'portfolio.summary.current_value_sell' => 'Güncel Değer (Satış)',
+    'portfolio.summary.profit_loss_buy' => 'Kâr / Zarar (Alış)',
+    'portfolio.summary.profit_loss_sell' => 'Kâr / Zarar (Satış)',
 
     'portfolio.form.title' => 'Portföye Ekle',
     'portfolio.form.currency' => 'Döviz',

--- a/portfolio.php
+++ b/portfolio.php
@@ -763,11 +763,22 @@ $annualizedReturn = ($oldestDate && $analyticsCost > 0)
                 <p class="card-value"><?= formatTRY((float) $summary['total_cost']) ?></p>
             </div>
             <div class="card">
-                <h3><?= t('portfolio.summary.current_value') ?></h3>
+                <h3><?= t('portfolio.summary.current_value_buy') ?></h3>
+                <p class="card-value"><?= formatTRY((float) ($summary['total_value_buy'] ?? $summary['total_value'])) ?></p>
+            </div>
+            <div class="card">
+                <h3><?= t('portfolio.summary.current_value_sell') ?></h3>
                 <p class="card-value"><?= formatTRY((float) $summary['total_value']) ?></p>
             </div>
+            <div class="card <?= ($summary['profit_loss_buy'] ?? $summary['profit_loss']) >= 0 ? 'card-profit' : 'card-loss' ?>">
+                <h3><?= t('portfolio.summary.profit_loss_buy') ?></h3>
+                <p class="card-value">
+                    <?= formatTRY((float) ($summary['profit_loss_buy'] ?? $summary['profit_loss'])) ?>
+                    <small>(% <?= formatNumberLocalized((float) ($summary['profit_percent_buy'] ?? $summary['profit_percent']), 2) ?>)</small>
+                </p>
+            </div>
             <div class="card <?= $summary['profit_loss'] >= 0 ? 'card-profit' : 'card-loss' ?>">
-                <h3><?= t('portfolio.summary.profit_loss') ?></h3>
+                <h3><?= t('portfolio.summary.profit_loss_sell') ?></h3>
                 <p class="card-value">
                     <?= formatTRY((float) $summary['profit_loss']) ?>
                     <small>(% <?= formatNumberLocalized((float) $summary['profit_percent'], 2) ?>)</small>


### PR DESCRIPTION
## Özet

"Güncel Değer" ve "Kâr / Zarar" artık **Alış (bid)** ve **Satış (ask)** kuruna göre ayrı ayrı gösteriliyor — hem `portfolio.php` hem `index.php` özet widget'ında.

- **Alış (bid)** = elimdekini bugün bozdurursam/satarsam alacağım değer → **birincil** (highlight + badge)
- **Satış (ask)** = yeniden alma değeri (mevcut davranış)

## Değişiklikler

- **`includes/Portfolio.php`**: ana SELECT'e `value_try_buy` (`amount × COALESCE(r.buy_rate, p.buy_rate)`) + `profit_percent_buy` eklendi. `getSummary()` artık `total_value_buy`, `profit_loss_buy`, `profit_percent_buy` da döndürüyor. Mevcut satış-bazlı alanlar korundu (geriye uyumlu).
- **`portfolio.php`**: özet 3 → 5 kart (Maliyet, Güncel Değer Alış, Güncel Değer Satış, Kâr/Zarar Alış, Kâr/Zarar Satış).
- **`index.php`**: portföy özeti widget'ı aynı ayrımı yansıtıyor; badge alış-bazlı.
- **`locales/tr.php` + `en.php`**: yeni etiketler (`current_value_buy/sell`, `profit_loss_buy/sell`). Eski `current_value`/`profit_loss` etiketleri diğer sayfalar (analytics, goals, leverage) için duruyor.

## Test (lokal)

`getSummary()` doğrulandı (19 kayıt): total_value=394.163,63 / total_value_buy=392.566,30 / profit_loss=−18.214,45 / profit_loss_buy=−19.811,78. PHP 8.4 syntax temiz (5 dosya).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
