### PR TITLE
feat: tablo K/Z % sütununu Alış/Satış olarak böl

### DIFF
--- a/locales/en.php
+++ b/locales/en.php
@@ -106,6 +106,8 @@ return [
     'portfolio.table.cost' => 'Cost (TRY)',
     'portfolio.table.value' => 'Value (TRY)',
     'portfolio.table.pl_percent' => 'P/L (%)',
+    'portfolio.table.pl_percent_buy' => 'P/L Bid (%)',
+    'portfolio.table.pl_percent_sell' => 'P/L Ask (%)',
     'portfolio.table.date' => 'Date',
     'portfolio.table.actions' => 'Actions',
     'portfolio.table.delete_confirm' => 'Are you sure you want to delete this record?',

--- a/locales/tr.php
+++ b/locales/tr.php
@@ -106,6 +106,8 @@ return [
     'portfolio.table.cost' => 'Maliyet (₺)',
     'portfolio.table.value' => 'Değer (₺)',
     'portfolio.table.pl_percent' => 'K/Z (%)',
+    'portfolio.table.pl_percent_buy' => 'K/Z Alış (%)',
+    'portfolio.table.pl_percent_sell' => 'K/Z Satış (%)',
     'portfolio.table.date' => 'Tarih',
     'portfolio.table.actions' => 'İşlemler',
     'portfolio.table.delete_confirm' => 'Silmek istediğinize emin misiniz?',

--- a/portfolio.php
+++ b/portfolio.php
@@ -1923,14 +1923,15 @@ $annualizedReturn = ($oldestDate && $analyticsCost > 0)
                                 <th scope="col" class="text-right"><?= t('portfolio.table.current_rate') ?></th>
                                 <th scope="col" class="text-right"><?= t('portfolio.table.cost') ?></th>
                                 <th scope="col" class="text-right"><?= t('portfolio.table.value') ?></th>
-                                <th scope="col" class="text-right"><?= t('portfolio.table.pl_percent') ?></th>
+                                <th scope="col" class="text-right"><?= t('portfolio.table.pl_percent_buy') ?></th>
+                                <th scope="col" class="text-right"><?= t('portfolio.table.pl_percent_sell') ?></th>
                                 <th scope="col"><?= t('portfolio.table.date') ?></th>
                                 <th scope="col"><?= t('portfolio.table.actions') ?></th>
                             </tr>
                         </thead>
                         <tbody>
                             <?php foreach ($filteredItems as $item): ?>
-                                <?php $pl = (float) $item['profit_percent']; ?>
+                                <?php $pl = (float) $item['profit_percent']; $plBuy = (float) ($item['profit_percent_buy'] ?? $pl); ?>
                                 <tr data-id="<?= (int) $item['id'] ?>">
                                     <td class="col-checkbox">
                                         <input type="checkbox" class="row-checkbox" value="<?= (int) $item['id'] ?>">
@@ -2012,6 +2013,9 @@ $annualizedReturn = ($oldestDate && $analyticsCost > 0)
                                     </td>
                                     <td class="text-right mono"><?= formatTRY((float) $item['cost_try']) ?></td>
                                     <td class="text-right mono"><?= formatTRY((float) $item['value_try']) ?></td>
+                                    <td class="text-right <?= changeClass($plBuy) ?>">
+                                        <?= changeArrow($plBuy) ?> % <?= formatNumberLocalized(abs($plBuy), 2) ?>
+                                    </td>
                                     <td class="text-right <?= changeClass($pl) ?>">
                                         <?= changeArrow($pl) ?> % <?= formatNumberLocalized(abs($pl), 2) ?>
                                     </td>


### PR DESCRIPTION
## Özet

Portföy kayıtları tablosundaki tek **"K/Z (%)"** sütunu, satır bazında **K/Z Alış (%)** ve **K/Z Satış (%)** olmak üzere ikiye bölündü — özet kartlarındaki Alış/Satış ayrımıyla tutarlı.

- **K/Z Alış (%)** = `profit_percent_buy` (alış/bid kuru — bozdurma) → birincil, önce
- **K/Z Satış (%)** = `profit_percent` (satış/ask kuru) → mevcut

## Değişiklikler

- **`portfolio.php`**: tabloya 2. P/L% sütunu eklendi (1 `<th>` + 1 `<td>`). `$plBuy` satır bazında `profit_percent_buy`'dan; renk/ok (`changeClass`/`changeArrow`) ikisinde de korundu.
- **`locales/tr.php` + `en.php`**: `pl_percent_buy` ("K/Z Alış (%)"), `pl_percent_sell` ("K/Z Satış (%)"). Eski `pl_percent` etiketi duruyor.

`profit_percent_buy` zaten PR #30'da `Portfolio.php` SELECT'ine eklenmişti; bu PR sadece tabloda gösteriyor. PHP 8.4 syntax temiz, colspan etkilenmiyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
