### PR TITLE
fix: enflasyon notu placeholder ({{}}) düzeltmesi

### DIFF
--- a/locales/en.php
+++ b/locales/en.php
@@ -80,7 +80,7 @@ return [
     'portfolio.summary.profit_loss_sell' => 'Profit / Loss (Ask)',
     'portfolio.summary.inflation_target' => 'Inflation-Protected Target (1 yr)',
     'portfolio.summary.inflation_required_yield' => 'Required annual return',
-    'portfolio.summary.inflation_note' => 'Inflation: {rate}% ({source}, {date})',
+    'portfolio.summary.inflation_note' => 'Inflation: {{rate}}% ({{source}}, {{date}})',
     'admin.inflation_settings' => 'Inflation Settings',
     'admin.inflation_settings_desc' => 'Annual ENAG inflation rate used for the inflation-protected target.',
     'admin.inflation_settings_saved' => 'Inflation settings saved.',

--- a/locales/tr.php
+++ b/locales/tr.php
@@ -80,7 +80,7 @@ return [
     'portfolio.summary.profit_loss_sell' => 'Kâr / Zarar (Satış)',
     'portfolio.summary.inflation_target' => 'Enflasyon Korumalı Hedef (1 yıl)',
     'portfolio.summary.inflation_required_yield' => 'Gereken yıllık getiri',
-    'portfolio.summary.inflation_note' => 'Enflasyon: %{rate} ({source}, {date})',
+    'portfolio.summary.inflation_note' => 'Enflasyon: %{{rate}} ({{source}}, {{date}})',
     'admin.inflation_settings' => 'Enflasyon Ayarları',
     'admin.inflation_settings_desc' => 'Enflasyon korumalı hedef için yıllık ENAG enflasyon oranı.',
     'admin.inflation_settings_saved' => 'Enflasyon ayarları kaydedildi.',


### PR DESCRIPTION
## Sorun

Portföy 'Enflasyon Korumalı Hedef' kartında alt not ham görünüyordu: `Enflasyon: %{rate} ({source}, {date})`.

## Neden

`t()` fonksiyonu **çift süslü parantez** `{{placeholder}}` ile interpolasyon yapıyor (bkz. `portfolio.table.title` => 'Portföy ({{count}} kalem)'). Ben tek `{...}` yazmıştım, o yüzden değişmedi.

## Çözüm

`inflation_note` etiketinde `{rate}/{source}/{date}` → `{{rate}}/{{source}}/{{date}}` (tr + en).

Render testi: `Enflasyon: %53,13 (manual, 2026-06-16)` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)